### PR TITLE
stringify check constraint name

### DIFF
--- a/lib/exclusive_arc/version.rb
+++ b/lib/exclusive_arc/version.rb
@@ -1,3 +1,3 @@
 module ExclusiveArc
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end

--- a/lib/generators/exclusive_arc_generator.rb
+++ b/lib/generators/exclusive_arc_generator.rb
@@ -110,7 +110,7 @@ class ExclusiveArcGenerator < ActiveRecord::Generators::Base
     add_check_constraint(
       :#{table_name},
       "#{check_constraint}",
-      name: :#{arc}
+      name: "#{arc}"
     )
       RUBY
     end

--- a/test/exclusive_arc/model_test.rb
+++ b/test/exclusive_arc/model_test.rb
@@ -95,6 +95,14 @@ class ModelTest < ActiveSupport::TestCase
     assert_equal [], Government.joins(:city)
   end
 
+  test "it can rollback migration" do
+    CONNECTION.transaction do
+      migrate_exclusive_arc(%w[Government region city county state], :down)
+
+      raise ActiveRecord::Rollback
+    end
+  end
+
   private
 
   def assert_arc_not_exclusive(government)


### PR DESCRIPTION
when rolling back a check constraint in an ActiveRecord migration, the name needs to be a string and not a symbol, or the constraint won’t be known to exist