### PR TITLE
make generator command re-runnable

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,15 @@ class CommentCommentableExclusiveArcPostCommentPage < ActiveRecord::Migration[7.
 end
 ```
 
+The registration in the model will be updated as well.
+
+``` ruby
+class Comment < ApplicationRecord
+  include ExclusiveArc::Model
+  has_exclusive_arc :commentable, [:post, :comment, :page]
+end
+```
+
 ### Compatibility
 
 Currently `activerecord-exclusive-arc` is tested against a matrix of:

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ types of ActiveRecord models.
 
 ### Doesn’t Rails already provide a way to do this?
 
-Yeah but... [here’s a post about why this
-exists](https://waymondo.com/posts/are-exclusive-arcs-evil/).
+Yes but [here’s a post about why this exists](https://waymondo.com/posts/are-exclusive-arcs-evil/).
 
 ### So how does this work?
 
@@ -80,14 +79,14 @@ Continuing with our example, the generator command would also produce a migratio
 this:
 
 ```ruby
-class CommentCommentableExclusiveArc < ActiveRecord::Migration[7.0]
+class CommentCommentableExclusiveArcPostComment < ActiveRecord::Migration[7.0]
   def change
     add_reference :comments, :post, foreign_key: true, index: {where: "post_id IS NOT NULL"}
     add_reference :comments, :comment, foreign_key: true, index: {where: "comment_id IS NOT NULL"}
     add_check_constraint(
       :comments,
       "(CASE WHEN post_id IS NULL THEN 0 ELSE 1 END + CASE WHEN comment_id IS NULL THEN 0 ELSE 1 END) = 1",
-      name: :commentable
+      name: "commentable"
     )
   end
 end
@@ -118,6 +117,34 @@ Adds an Exclusive Arc to an ActiveRecord model and generates the migration for i
 Notably, if you want to make an Exclusive Arc optional, you can use the `--optional` flag. This will
 adjust the definition in your `ActiveRecord` model and loosen both the validation and database check
 constraint so that there can be 0 or 1 foreign keys set for the polymorphic reference.
+
+### Updating an existing exclusive arc
+
+If you need to add an additional polymorphic option to an existing exclusive arc, you can simply run
+the generator command again with the additional target. Existing references will be skipped and the
+check constraint will be removed and re-added in a reversible manner.
+
+```
+bin/rails g exclusive_arc Comment commentable post comment page
+```
+
+``` ruby
+class CommentCommentableExclusiveArcPostCommentPage < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :comments, :page, foreign_key: true, index: {where: "page_id IS NOT NULL"}
+    remove_check_constraint(
+      :comments,
+      "(CASE WHEN post_id IS NULL THEN 0 ELSE 1 END + CASE WHEN comment_id IS NULL THEN 0 ELSE 1 END) = 1",
+      name: "commentable"
+    )
+    add_check_constraint(
+      :comments,
+      "(CASE WHEN post_id IS NULL THEN 0 ELSE 1 END + CASE WHEN comment_id IS NULL THEN 0 ELSE 1 END + CASE WHEN page_id IS NULL THEN 0 ELSE 1 END) = 1",
+      name: "commentable"
+    )
+  end
+end
+```
 
 ### Compatibility
 

--- a/lib/exclusive_arc/version.rb
+++ b/lib/exclusive_arc/version.rb
@@ -1,3 +1,3 @@
 module ExclusiveArc
-  VERSION = "0.2.3"
+  VERSION = "0.3.0"
 end

--- a/lib/generators/exclusive_arc_generator.rb
+++ b/lib/generators/exclusive_arc_generator.rb
@@ -52,8 +52,8 @@ class ExclusiveArcGenerator < ActiveRecord::Generators::Base
 
     def add_references
       belong_tos.map do |reference|
-        add_reference(reference)
-      end.join("\n")
+        add_reference(reference) unless column_exists?(reference)
+      end.compact.join("\n")
     end
 
     def add_reference(reference)
@@ -96,6 +96,13 @@ class ExclusiveArcGenerator < ActiveRecord::Generators::Base
       class_name.constantize.reflections[reference].klass.table_name
     rescue
       reference.tableize
+    end
+
+    def column_exists?(reference)
+      foreign_key = foreign_key_name(reference)
+      class_name.constantize.column_names.include?(foreign_key)
+    rescue
+      false
     end
 
     def foreign_key_name(reference)

--- a/lib/generators/exclusive_arc_generator.rb
+++ b/lib/generators/exclusive_arc_generator.rb
@@ -31,15 +31,20 @@ class ExclusiveArcGenerator < ActiveRecord::Generators::Base
       model_file_path,
       class_name.demodulize,
       <<~RB
-        #{indents}has_exclusive_arc #{model_exclusive_arcs}
-      RB
-    )
-    inject_into_class(
-      model_file_path,
-      class_name.demodulize,
-      <<~RB
         #{indents}include ExclusiveArc::Model
       RB
+    )
+    gsub_file(
+      model_file_path,
+      /has_exclusive_arc :#{arc}(.*)$/,
+      ""
+    )
+    inject_into_file(
+      model_file_path,
+      <<~RB,
+        #{indents}has_exclusive_arc #{model_exclusive_arcs}
+      RB
+      after: "include ExclusiveArc::Model\n"
     )
   end
 
@@ -78,11 +83,22 @@ class ExclusiveArcGenerator < ActiveRecord::Generators::Base
     end
 
     def migration_file_name
-      "#{class_name.delete(":").underscore}_#{arc}_exclusive_arc.rb"
+      "#{class_name.delete(":").underscore}_#{arc}_exclusive_arc_#{belong_tos.map(&:underscore).join("_")}.rb"
     end
 
     def migration_class_name
-      [class_name.delete(":").singularize, arc.classify, "ExclusiveArc"].join
+      (
+        [class_name.delete(":").singularize, arc.classify, "ExclusiveArc"] |
+        belong_tos.map(&:classify)
+      ).join
+    end
+
+    def existing_check_constraint
+      @existing_check_constraint ||=
+        class_name.constantize.connection.check_constraints(class_name.constantize.table_name)
+          .find { |constraint| constraint.name == arc }
+    rescue
+      nil
     end
 
     def reference_type(reference)
@@ -111,9 +127,21 @@ class ExclusiveArcGenerator < ActiveRecord::Generators::Base
       "#{reference}_id"
     end
 
+    def remove_check_constraint
+      return if options[:skip_check_constraint]
+      return unless existing_check_constraint
+      <<-RUBY.chomp
+    remove_check_constraint(
+      :#{table_name},
+      "#{existing_check_constraint.expression.squish}",
+      name: "#{arc}"
+    )
+      RUBY
+    end
+
     def add_check_constraint
       return if options[:skip_check_constraint]
-      <<-RUBY
+      <<-RUBY.chomp
     add_check_constraint(
       :#{table_name},
       "#{check_constraint}",

--- a/lib/generators/exclusive_arc_generator.rb
+++ b/lib/generators/exclusive_arc_generator.rb
@@ -129,7 +129,8 @@ class ExclusiveArcGenerator < ActiveRecord::Generators::Base
 
     def remove_check_constraint
       return if options[:skip_check_constraint]
-      return unless existing_check_constraint
+      return unless existing_check_constraint&.expression
+
       <<-RUBY.chomp
     remove_check_constraint(
       :#{table_name},

--- a/lib/generators/templates/migration.rb.erb
+++ b/lib/generators/templates/migration.rb.erb
@@ -1,6 +1,7 @@
 class <%= migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
   def change
 <%= add_references %>
+<%= remove_check_constraint %>
 <%= add_check_constraint %>
   end
 end

--- a/test/exclusive_arc/generator_test.rb
+++ b/test/exclusive_arc/generator_test.rb
@@ -2,25 +2,27 @@ require "test_helper"
 
 class GeneratorTest < Rails::Generators::TestCase
   tests ExclusiveArcGenerator
-  TMP_DIR = File.expand_path("../../tmp", __dir__)
+  TMP_DIR = File.expand_path("../../tmp/generator", __dir__)
   destination TMP_DIR
 
   def setup
     prepare_destination
-    model_path = File.join(TMP_DIR, "app", "models", "government.rb")
-    FileUtils.mkdir_p(File.dirname(model_path))
-    File.write(
-      model_path,
-      <<~RAW
-        class Government < ActiveRecord::Base
-        end
-      RAW
-    )
+    ["government", "comment"].each do |model|
+      model_path = File.join(TMP_DIR, "app", "models", "#{model}.rb")
+      FileUtils.mkdir_p(File.dirname(model_path))
+      File.write(
+        model_path,
+        <<~RAW
+          class #{model.classify} < ActiveRecord::Base
+          end
+        RAW
+      )
+    end
   end
 
   test "it generates an exclusive arc migration and injects into model" do
     run_generator %w[Government region city county state]
-    assert_migration "db/migrate/government_region_exclusive_arc.rb" do |migration|
+    assert_migration "db/migrate/government_region_exclusive_arc_city_county_state.rb" do |migration|
       if SUPPORTS_UUID
         assert_match(/add_reference :governments, :city, type: :uuid, foreign_key: true, index:/, migration)
       else
@@ -35,11 +37,23 @@ class GeneratorTest < Rails::Generators::TestCase
     assert_file "app/models/government.rb", /has_exclusive_arc :region, \[:city, :county, :state\]/
   end
 
+  test "running generator twice updates model declaration" do
+    run_generator %w[Comment commentable comment post]
+    assert_file "app/models/comment.rb", /include ExclusiveArc::Model/
+    assert_file "app/models/comment.rb", /has_exclusive_arc :commentable, \[:comment, :post\]/
+    run_generator %w[Comment commentable comment post page]
+    assert_file "app/models/comment.rb", /include ExclusiveArc::Model/
+    assert_file "app/models/comment.rb", /has_exclusive_arc :commentable, \[:comment, :post, :page\]/
+    assert_file "app/models/comment.rb" do |file|
+      refute_match(/has_exclusive_arc :commentable, \[:comment, ::post\]/, file)
+    end
+  end
+
   test "it infers non traditional foreign key and builds appropriate migration" do
     city_foreign_key = Government.reflections["city"].foreign_key
     Government.reflections["city"].instance_variable_set(:@foreign_key, "foo_id")
     run_generator %w[Government region city county state]
-    assert_migration "db/migrate/government_region_exclusive_arc.rb" do |migration|
+    assert_migration "db/migrate/government_region_exclusive_arc_city_county_state.rb" do |migration|
       assert_match(/add_column :governments, :foo_id/, migration)
       assert_match(/add_foreign_key :governments, :cities, column: :foo_id/, migration)
       assert_match(/add_index :governments, :foo_id, where: "foo_id IS NOT NULL"/, migration)
@@ -51,7 +65,7 @@ class GeneratorTest < Rails::Generators::TestCase
   test "it does not add reference when column already exists" do
     Government.stub(:column_names, ["id", "name", "city_id"]) do
       run_generator %w[Government region city county state]
-      assert_migration "db/migrate/government_region_exclusive_arc.rb" do |migration|
+      assert_migration "db/migrate/government_region_exclusive_arc_city_county_state.rb" do |migration|
         assert_match(/add_reference :governments, :county/, migration)
         assert_match(/add_reference :governments, :state/, migration)
         refute_match(/add_reference :governments, :city/, migration)
@@ -59,9 +73,19 @@ class GeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  test "running with existing check constraint removes and re-adds" do
+    run_generator %w[Comment commentable comment post]
+    assert_migration "db/migrate/comment_commentable_exclusive_arc_comment_post.rb" do |migration|
+      assert_match(/add_reference :comments, :comment/, migration)
+      refute_match(/add_reference :comments, :post/, migration)
+      assert_match(/remove_check_constraint\(\n(\s*):comments/, migration)
+      assert_match(/add_check_constraint\(\n(\s*):comments/, migration)
+    end
+  end
+
   test "it generates an optional exclusive arc migration and model configuration" do
     run_generator ["Government", "region", "city", "county", "state", "--optional"]
-    assert_migration "db/migrate/government_region_exclusive_arc.rb" do |migration|
+    assert_migration "db/migrate/government_region_exclusive_arc_city_county_state.rb" do |migration|
       assert_match(/\(CASE(.*)\) <= 1/, migration)
     end
     assert_file "app/models/government.rb", /has_exclusive_arc :region, \[:city, :county, :state\], optional: true/
@@ -75,21 +99,21 @@ class GeneratorTest < Rails::Generators::TestCase
 
   test "it can opt out of foreign key constraints" do
     run_generator ["Government", "region", "city", "county", "state", "--skip-foreign-key-constraints"]
-    assert_migration "db/migrate/government_region_exclusive_arc.rb" do |migration|
+    assert_migration "db/migrate/government_region_exclusive_arc_city_county_state.rb" do |migration|
       refute_match(/foreign_key: true/, migration)
     end
   end
 
   test "it can opt out of foreign key indexes" do
     run_generator ["Government", "region", "city", "county", "state", "--skip-foreign-key-indexes"]
-    assert_migration "db/migrate/government_region_exclusive_arc.rb" do |migration|
+    assert_migration "db/migrate/government_region_exclusive_arc_city_county_state.rb" do |migration|
       refute_match(/index:/, migration)
     end
   end
 
   test "it can opt out of check constraint" do
     run_generator ["Government", "region", "city", "county", "state", "--skip-check-constraint"]
-    assert_migration "db/migrate/government_region_exclusive_arc.rb" do |migration|
+    assert_migration "db/migrate/government_region_exclusive_arc_city_county_state.rb" do |migration|
       refute_match(/add_check_constraint/, migration)
     end
   end

--- a/test/exclusive_arc/generator_test.rb
+++ b/test/exclusive_arc/generator_test.rb
@@ -48,6 +48,17 @@ class GeneratorTest < Rails::Generators::TestCase
     Government.reflections["city"].instance_variable_set(:@foreign_key, city_foreign_key)
   end
 
+  test "it does not add reference when column already exists" do
+    Government.stub(:column_names, ["id", "name", "city_id"]) do
+      run_generator %w[Government region city county state]
+      assert_migration "db/migrate/government_region_exclusive_arc.rb" do |migration|
+        assert_match(/add_reference :governments, :county/, migration)
+        assert_match(/add_reference :governments, :state/, migration)
+        refute_match(/add_reference :governments, :city/, migration)
+      end
+    end
+  end
+
   test "it generates an optional exclusive arc migration and model configuration" do
     run_generator ["Government", "region", "city", "county", "state", "--optional"]
     assert_migration "db/migrate/government_region_exclusive_arc.rb" do |migration|

--- a/test/exclusive_arc/model_test.rb
+++ b/test/exclusive_arc/model_test.rb
@@ -1,10 +1,6 @@
 require "test_helper"
 
 class ModelTest < ActiveSupport::TestCase
-  def setup
-    ActiveRecord::Base.descendants.each(&:reset_column_information)
-  end
-
   class Foo < ActiveRecord::Base
     include ExclusiveArc::Model
     belongs_to :bong, foreign_key: :bing_bong_id
@@ -101,7 +97,7 @@ class ModelTest < ActiveSupport::TestCase
 
   test "it can rollback migration" do
     CONNECTION.transaction do
-      GovernmentRegionExclusiveArcCityCountyState.migrate(:down)
+      TestMigration.migrate(:down)
 
       raise ActiveRecord::Rollback
     end

--- a/test/exclusive_arc/model_test.rb
+++ b/test/exclusive_arc/model_test.rb
@@ -1,6 +1,10 @@
 require "test_helper"
 
 class ModelTest < ActiveSupport::TestCase
+  def setup
+    ActiveRecord::Base.descendants.each(&:reset_column_information)
+  end
+
   class Foo < ActiveRecord::Base
     include ExclusiveArc::Model
     belongs_to :bong, foreign_key: :bing_bong_id
@@ -97,7 +101,7 @@ class ModelTest < ActiveSupport::TestCase
 
   test "it can rollback migration" do
     CONNECTION.transaction do
-      migrate_exclusive_arc(%w[Government region city county state], :down)
+      GovernmentRegionExclusiveArcCityCountyState.migrate(:down)
 
       raise ActiveRecord::Rollback
     end

--- a/test/support/database.rb
+++ b/test/support/database.rb
@@ -1,11 +1,5 @@
 CONNECTION = ActiveRecord::Base.connection
 
-def truncate_db
-  CONNECTION.tables.each do |table|
-    CONNECTION.execute("TRUNCATE #{table} RESTART IDENTITY CASCADE")
-  end
-end
-
 CONNECTION.tables.each do |table|
   next unless CONNECTION.table_exists?(table)
 
@@ -15,10 +9,6 @@ end
 SUPPORTS_UUID = ENV["DATABASE_ADAPTER"] != "sqlite3"
 
 ActiveRecord::Schema.define do
-  create_table :governments do |t|
-    t.string :name
-  end
-
   if SUPPORTS_UUID
     create_table :cities, id: :uuid, default: -> { "gen_random_uuid()" } do |t|
       t.string :name
@@ -35,6 +25,21 @@ ActiveRecord::Schema.define do
 
   create_table :states do |t|
     t.string :name
+  end
+
+  create_table :governments do |t|
+    t.string :name
+    if SUPPORTS_UUID
+      t.references :city, type: :uuid, foreign_key: true
+    else
+      t.references :city, foreign_key: true
+    end
+    t.references :county, foreign_key: true
+    t.references :state, foreign_key: true
+    t.check_constraint(
+      "(CASE WHEN city_id IS NULL THEN 0 ELSE 1 END + CASE WHEN county_id IS NULL THEN 0 ELSE 1 END + CASE WHEN state_id IS NULL THEN 0 ELSE 1 END) = 1",
+      name: "region"
+    )
   end
 
   create_table :posts
@@ -73,19 +78,18 @@ end
 class Post < ActiveRecord::Base
   include ExclusiveArc::Model
   has_many :comments
-  has_exclusive_arc :commentable, [:comment, :post]
+  has_exclusive_arc :commentable, %i[comment post]
 end
 
-def migrate_exclusive_arc(args)
-  tmp_dir = File.expand_path("../../tmp", __dir__)
-  FileUtils.rm_f Dir.glob("#{tmp_dir}/**/*")
-  Rails::Generators.invoke("exclusive_arc", args + ["--quiet"], destination_root: tmp_dir)
-  Dir[File.join(tmp_dir, "db/migrate/*.rb")].sort.each { |file| require file }
-  targets = args[2..]
-  (
-    [args[0].delete(":").classify, args[1].classify, "ExclusiveArc"] |
-    targets.map(&:classify)
-  ).join.constantize.migrate(:up)
+class TestMigration < ActiveRecord::Migration[ActiveRecord::Migration.current_version]
+  def change
+    add_reference :governments, :city, type: :uuid, foreign_key: true, index: {where: "city_id IS NOT NULL"}
+    add_reference :governments, :county, foreign_key: true, index: {where: "county_id IS NOT NULL"}
+    add_reference :governments, :state, foreign_key: true, index: {where: "state_id IS NOT NULL"}
+    add_check_constraint(
+      :governments,
+      "(CASE WHEN city_id IS NULL THEN 0 ELSE 1 END + CASE WHEN county_id IS NULL THEN 0 ELSE 1 END + CASE WHEN state_id IS NULL THEN 0 ELSE 1 END) = 1",
+      name: "region"
+    )
+  end
 end
-
-migrate_exclusive_arc(%w[Government region city county state])


### PR DESCRIPTION
this makes the generator command smart enough so that it can be re-run to add additional references,
replace the check constraint with an updated one, and replace the model registration