### PR TITLE
fix rails matrix versioning

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,12 +28,12 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 3.2
-          - 2.7
+          - "3.2"
+          - "2.7"
         rails: 
-          - 6.1
-          - 7.0
-          - 7.1
+          - "6.1"
+          - "7.0"
+          - "7.1"
         database_adapter:
           - sqlite3
           - postgresql

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ if (rails_version = ENV["RAILS_VERSION"])
 else
   gem "rails"
 end
+gem "pg"
+gem "sqlite3"
 gem "standard", "~> 1.26"
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,11 @@
 source "https://rubygems.org"
 
 gem "debug"
-gem "minitest"
-gem "rails", "~> #{ENV.fetch("RAILS_VERSION", "7.0")}"
-gem "rake"
-gem "pg"
-gem "sqlite3"
+if (rails_version = ENV["RAILS_VERSION"])
+  gem "rails", "~> #{rails_version}.0"
+else
+  gem "rails"
+end
 gem "standard", "~> 1.26"
 
 gemspec


### PR DESCRIPTION
with github's matrix variables, if you supply `7.0`, this ends up being interpreted as an ENV variable of `7`. using the `~>` in the gemfile would instead install rails 7.1.x.

by turning it into a string and adding a patch number resolution to the gemfile version, we can be sure that `~> "7.0.0"` will always install 7.0.x.